### PR TITLE
Fix declaration/definition structure to make code compile with GCC 10

### DIFF
--- a/STM32Cube/Core/Inc/canfilter.h
+++ b/STM32Cube/Core/Inc/canfilter.h
@@ -8,14 +8,14 @@
 #ifndef INC_CANFILTER_H_
 #define INC_CANFILTER_H_
 
-CAN_TxHeaderTypeDef TxHeader;
-uint8_t TxData[8];
-uint32_t TxMailbox;
-uint8_t RxData[8];
-uint32_t TxMailbox;
-CAN_RxHeaderTypeDef RxHeader;
+extern CAN_TxHeaderTypeDef TxHeader;
+extern uint8_t TxData[8];
+extern uint32_t TxMailbox;
+extern CAN_RxHeaderTypeDef RxHeader;
+extern uint8_t RxData[8];
+extern uint16_t rpm;
+
 void canloop(CAN_HandleTypeDef *can1, CAN_HandleTypeDef *can2);
 void filtercan(int airbid, uint8_t *data[8]);
-uint16_t rpm;
 
 #endif /* INC_CANFILTER_H_ */

--- a/STM32Cube/Core/Src/canfilter.c
+++ b/STM32Cube/Core/Src/canfilter.c
@@ -21,6 +21,12 @@ uint8_t RxData[8];
 uint16_t rpm;
 /* USER CODE END PD */
 
+/* Private function prototypes -----------------------------------------------*/
+/* USER CODE BEGIN PFP */
+void copyData(void);
+void filtercan(int airbid, uint8_t data[8]);
+/* USER CODE END PFP */
+
 void canloop(CAN_HandleTypeDef *can1, CAN_HandleTypeDef *can2) {
 	while (1) {
 		// Receive Message from Can1 & send to CAN2:
@@ -71,7 +77,7 @@ void copyData() {
 	filtercan(RxHeader.StdId, TxData);
 
 }
-void filtercan(int airbid, uint8_t *data[8]) {
+void filtercan(int airbid, uint8_t data[8]) {
 	if (airbid == 0x316) {
 		uint8_t d1 = data[2];
 		uint8_t d2 = data[3];

--- a/STM32Cube/Core/Src/canfilter.c
+++ b/STM32Cube/Core/Src/canfilter.c
@@ -9,7 +9,18 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 #include <string.h>
-#include "canfilter.h"
+/* USER CODE END Includes */
+
+/* Private define ------------------------------------------------------------*/
+/* USER CODE BEGIN PD */
+CAN_TxHeaderTypeDef TxHeader;
+uint8_t TxData[8];
+uint32_t TxMailbox;
+CAN_RxHeaderTypeDef RxHeader;
+uint8_t RxData[8];
+uint16_t rpm;
+/* USER CODE END PD */
+
 void canloop(CAN_HandleTypeDef *can1, CAN_HandleTypeDef *can2) {
 	while (1) {
 		// Receive Message from Can1 & send to CAN2:


### PR DESCRIPTION
Thanks for sharing this interesting project!

I tried to build it myself. But the most recent CubeIDE version with GCC 10 gives multiple linker errors, see one example below:

> c:/program files (x86)/arm/10 2020-q4-major/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld.exe: ./Core/Src/main.o:C:\Users\Public\Documents\STM\Canfilter-master\STM32Cube\Debug/../Core/Inc/canfilter.h:11: multiple definition of `TxHeader'; ./Core/Src/canfilter.o:C:\Users\Public\Documents\STM\Canfilter-master\STM32Cube\Debug/../Core/Inc/canfilter.h:11: first defined here

Althought this can be fixed by adding the compiler flag `-fcommon`, the clean way is to correct the code to match the C-standard. Following article describes the problem: [Link](https://wiki.gentoo.org/wiki/Project:Toolchain/Gcc_10_porting_notes/fno_common)

For summarizing, variables shall only be defined in one place (one c-file). The related variable declaration in the .h file shall have an `extern` prefix, as it is only for informing other c-files of the existence of that variable.

I fixed canfilter.h and canfilter.c file in order to fulfill the c-standard. Now it compiles without errors. 

Please pull the change into main, so other people building the project don't run into the same problem.

Thanks!

